### PR TITLE
Avoid buggy getProjectRoot()

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "@storybook/types": "8.4.7",
     "auto": "^11.3.0",
     "find-cache-dir": "^5.0.0",
-    "find-up": "^7.0.0",
     "tsup": "^8.3.5",
     "typescript": "^5.7.2",
     "webpack": "^5.97.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,6 @@ importers:
       find-cache-dir:
         specifier: ^5.0.0
         version: 5.0.0
-      find-up:
-        specifier: ^7.0.0
-        version: 7.0.0
       tsup:
         specifier: ^8.3.5
         version: 8.3.5(typescript@5.7.2)
@@ -1102,10 +1099,6 @@ packages:
     resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==, tarball: https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  find-up@7.0.0:
-    resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==, tarball: https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz}
-    engines: {node: '>=18'}
-
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==, tarball: https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz}
 
@@ -1956,10 +1949,6 @@ packages:
 
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==, tarball: https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz}
-
-  unicorn-magic@0.1.0:
-    resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==, tarball: https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz}
-    engines: {node: '>=18'}
 
   universal-user-agent@6.0.1:
     resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==, tarball: https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz}
@@ -3215,12 +3204,6 @@ snapshots:
       locate-path: 7.2.0
       path-exists: 5.0.0
 
-  find-up@7.0.0:
-    dependencies:
-      locate-path: 7.2.0
-      path-exists: 5.0.0
-      unicorn-magic: 0.1.0
-
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
@@ -3995,8 +3978,6 @@ snapshots:
   typical@5.2.0: {}
 
   undici-types@6.20.0: {}
-
-  unicorn-magic@0.1.0: {}
 
   universal-user-agent@6.0.1: {}
 

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1,6 +1,6 @@
 import type { Options } from "@storybook/types";
 import type { Configuration } from "webpack";
-import { getProjectRoot, resolvePathInStorybookCache } from "./utils.js";
+import { resolvePathInStorybookCache } from "./utils.js";
 
 const virtualModuleFiles = [
   /storybook-config-entry\.js$/,
@@ -32,7 +32,6 @@ export const webpackFinal = async (config: Configuration, options: Options) => {
             },
           },
         ],
-        include: [getProjectRoot()],
         exclude: [/node_modules/, ...virtualModuleFiles],
       },
     ],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,6 @@
 import { join } from "node:path";
 
 import findCacheDirectory from "find-cache-dir";
-import { findUpSync } from "find-up";
 
 /**
  * Get the path of the file or directory with input name inside the Storybook cache directory:
@@ -21,59 +20,3 @@ export function resolvePathInStorybookCache(
 
   return join(cacheDirectory, sub, fileOrDirectoryName);
 }
-
-/**
- * @returns {string} The root directory of the project
- */
-export const getProjectRoot = () => {
-  let result: string | undefined;
-  // Allow manual override in cases where auto-detect doesn't work
-  // biome-ignore lint/complexity/useLiteralKeys: Ignore
-  if (process.env["STORYBOOK_PROJECT_ROOT"]) {
-    // biome-ignore lint/complexity/useLiteralKeys: Ignore
-    return process.env["STORYBOOK_PROJECT_ROOT"];
-  }
-
-  try {
-    const found = findUpSync(".git", { type: "directory" });
-    if (found) {
-      result = join(found, "..");
-    }
-  } catch (e) {
-    //
-  }
-  try {
-    const found = findUpSync(".svn", { type: "directory" });
-    if (found) {
-      result = result || join(found, "..");
-    }
-  } catch (e) {
-    //
-  }
-  try {
-    const found = findUpSync(".hg", { type: "directory" });
-    if (found) {
-      result = result || join(found, "..");
-    }
-  } catch (e) {
-    //
-  }
-
-  try {
-    const splitDirname = __dirname.split("node_modules");
-    result = result || (splitDirname.length >= 2 ? splitDirname[0] : undefined);
-  } catch (e) {
-    //
-  }
-
-  try {
-    const found = findUpSync(".yarn", { type: "directory" });
-    if (found) {
-      result = result || join(found, "..");
-    }
-  } catch (e) {
-    //
-  }
-
-  return result || process.cwd();
-};


### PR DESCRIPTION
[closes storybookjs/storybook/issues/14042]

Storybook fails to compile TypeScript when I use git worktrees and yarn.

This setup has two interesting properties:

* [git worktrees](https://git-scm.com/docs/git-worktree) don't have a `.git/` directory.
* Yarn doesn't put any code in `node_modules/`.

So [getProjectRoot()](https://github.com/storybookjs/addon-webpack5-compiler-babel/blob/d201e8c38157872535041e64a662b991bf2f0abe/src/utils.ts#L62-L67) doesn't find my top-level directory via either path. But it _does_ find a `node_modules/`! There's a `node_modules` inside the `addon-webpack5-compiler-babel` folder. So `getProjectRoot()` returns, `"/home/adam.hooper/src/myproject/.yarn/cache/@storybook-addon-webpack5-compiler-babel-npm-3.0.5-9ba7eaab05-32249b0dbf.zip/"`. And my TypeScript files outside of that directory don't match the include, so they don't get compiled.

Workaround: `STORYBOOK_PROJECT_ROOT=/ yarn storybook` can get Storybook up and running.

Solution: heck, why do we have `"include"` in the _first_ place? It looks like it's designed to translate all files; and we'll get the same effect if we simply remove it. This PR removes it.

Side-effects: now the babel loader ignores `STORYBOOK_PROJECT_ROOT`. That env variable [isn't documented](https://www.google.com/search?q=%22storybook_project_root%22), and it's unlikely somebody out there uses `STORYBOOK_PROJECT_ROOT` to filter out files for Babel translation.